### PR TITLE
Feature/documenting resize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ to maintain aspect ratio, so that scaling preserves sizes properly. We'll loosen
 resizing algorithm. However, in the meantime the demo code stylesheet has an example of how to do this.
 
 ## Available Methods
+### Rerendering
+You can always re-render the stickerbook by hand using the `triggerRender` method. This will simply call the internal
+fabric instance's `renderAll`. However, if you'd like to not only re-render but also want to recalculate positioning
+(due to a change in the container size etc.), you can call `resize` which will recalculate positioning for each canvas
+element and then redraw.
+
 ### Undo and Redo
 Any operation that was previously done can be undone (or redone) via the `undo` and `redo` method respectively:
 ```javascript

--- a/src/stickerbook.js
+++ b/src/stickerbook.js
@@ -62,8 +62,8 @@ class Stickerbook {
     this._updateCanvasState();
 
     // responsive logic
-    this._handleResize = this._handleResize.bind(this);
-    window.addEventListener('resize', this._handleResize);
+    this.resize = this.resize.bind(this);
+    window.addEventListener('resize', this.resize);
 
     // mark destroyed state
     this.isDestroyed = false;
@@ -262,7 +262,7 @@ class Stickerbook {
    *
    * @returns {Object} Stickerbook
    */
-  _handleResize() {
+  resize() {
     // theoretically, fabric supports setting CSS dimensions directly
     // (http://fabricjs.com/docs/fabric.Canvas.html#setDimensions)
     // however, using that mechanism seems to result in undesireable
@@ -581,7 +581,7 @@ class Stickerbook {
    * @return {undefined}
    */
   destroy() {
-    window.removeEventListener('resize', this._handleResize);
+    window.removeEventListener('resize', this.resize);
     this._canvas.dispose();
     delete this._canvas;
     delete this.backgroundManager;


### PR DESCRIPTION
Renaming the resize method to be more "public", and documenting it as well so that implementors know they have that option. Should fix #1 
