### PR TITLE
Feature/add demo prep script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -39,7 +39,7 @@ gulp.task('watch', () => {
   gulp.watch('src/*.js', ['build']);
 });
 
-gulp.task('serve', () => {
+gulp.task('serve', ['build-debug'], () => {
   // run dev server
   const staticServer = express();
   staticServer.use(express.static('demo'));


### PR DESCRIPTION
Tweaking the serve task to make sure that the demo copy of the Sticker Book is built before serving. A fresh clone didn't have the script, so the demo was broken