### PR TITLE
Updating event handlers to prevent users from continuing to add stickers

### DIFF
--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -14,9 +14,7 @@ const mouseDownHandler = function (evt) {
   }
 
   if(this.state._stickerAdded) {
-    // once the sticker has been added, we'll create a new, identical sticker/stamp so the user
-    // can continue placing stickers
-    return this.setSticker(this.state.sticker._element.src);
+    return this;
   }
 
   // add the sticker


### PR DESCRIPTION
This reflects a bug we saw in play testing where users were struggling
to edit stickers because they kept creating new stickers. Now, we'll
change the behavior to allow the user to keep editing and then
consciously grab another sticker before moving on