### PR TITLE
Small tweak to click collision behavior

### DIFF
--- a/src/stickerbook.js
+++ b/src/stickerbook.js
@@ -607,7 +607,8 @@ class Stickerbook {
       top: options.y,
       scaleX: options.xScale,
       scaleY: options.yScale,
-      angle: options.rotation
+      angle: options.rotation,
+      perPixelTargetFind: true
     });
     this.state.sticker.setCoords();
 


### PR DESCRIPTION
Now, clicking on a sticker only selects it if you click in an area with
alpha != 0, which a little more intuitive. It also should prevent
accidental selection in some cases