### PR TITLE
Preventing filled areas from being moved/selected/edited

### DIFF
--- a/src/fill-brush.js
+++ b/src/fill-brush.js
@@ -56,6 +56,7 @@ const FillBrush = fabric.util.createClass(fabric.BaseBrush, {
   onMouseUp: function () {
     var dataUrl = this.canvas.contextTop.canvas.toDataURL();
     fabric.Image.fromURL(dataUrl, (image) => {
+      image.set({ selectable: false });
       this.canvas.add(image);
       this.canvas.clearContext(this.canvas.contextTop);
       this.canvas.renderAll();


### PR DESCRIPTION
Fixing a bug where filled regions can be moved around as if they where an image.