### PR TITLE
Feature/custom brushes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ var stickerBook = new Stickerbook({
       'marker',
       'pattern',
       'pencil',
-      'spray'
+      'spray',
+
+      // a custom brush configured below
+      'mycustombrush'
     ], 
     
     // The available brush widths (in pixels)
@@ -56,7 +59,13 @@ var stickerBook = new Stickerbook({
     colors: [
       '#0000FF',
       '#FF0000'
-    ]
+    ],
+
+    // any custom brushes, the key of this object are the id to be used in the enabled list above, and the value must
+    // be a subclass of fabric.BaseBrush (via fabric.util.createClass(fabric.BaseBrush, { }) )
+    custom: {
+      mycustombrush: MyCustomBrush
+    }
   },
 
   // Whether or not to enable touch events

--- a/src/stickerbook.js
+++ b/src/stickerbook.js
@@ -1,6 +1,6 @@
 const Ajv = require('ajv');
 const validationRules = require('./validation-rules');
-const {CircleBrush, PencilBrush, SprayBrush} = fabric;
+const {BaseBrush, CircleBrush, PencilBrush, SprayBrush} = fabric;
 const FillBrush = require('./fill-brush');
 const BackgroundManager = require('./background-manager');
 const MarkerBrush = require('./marker-brush');
@@ -38,6 +38,11 @@ class Stickerbook {
     };
 
     this._validateConfig(configWithDefaults);
+
+    // apply any extra available brushes
+    if(configWithDefaults.brush.custom !== undefined) {
+      Object.assign(configWithDefaults, configWithDefaults.brush.custom)
+    }
 
     this._config = configWithDefaults;
 
@@ -340,6 +345,19 @@ class Stickerbook {
 
       throw new Error(formattedErrors.join(' '));
     }
+
+    if(config.brush.custom === undefined) {
+      return true;
+    }
+
+    Object.keys(config.brush.custom).forEach(key => {
+      if(config.brush.custom[key].prototype instanceof BaseBrush) {
+        return;
+      }
+
+      // this entry is not an actual fabric brush
+      throw new Error(`Custom brush "${key}" is not an instance of fabric.BaseBrush`);
+    });
 
     return true;
   }

--- a/src/stickerbook.js
+++ b/src/stickerbook.js
@@ -331,16 +331,17 @@ class Stickerbook {
   _validateConfig(config) {
     const validator = new Ajv();
     const valid = validator.validate(validationRules, config);
-    if(valid) {
-      return true;
+
+    if(!valid) {
+      const formattedErrors = validator.errors.map((error) => {
+        const field = error.dataPath.replace(/^\./, '');
+        return field + ' ' + error.message;
+      });
+
+      throw new Error(formattedErrors.join(' '));
     }
 
-    const formattedErrors = validator.errors.map((error) => {
-      const field = error.dataPath.replace(/^\./, '');
-      return field + ' ' + error.message;
-    });
-
-    throw new Error(formattedErrors.join(' '));
+    return true;
   }
 
   /**

--- a/src/stickerbook.js
+++ b/src/stickerbook.js
@@ -14,16 +14,6 @@ const {
 } = require('./event-handlers');
 const { calculateInnerDimensions } = require('./util');
 
-const BRUSHES = {
-  circle: CircleBrush,
-  eraser: PencilEraserBrush,
-  marker: MarkerBrush,
-  pattern: PatternBrush,
-  pencil: PencilBrush,
-  spray: SprayBrush,
-  fill: FillBrush
-};
-
 class Stickerbook {
   /**
    * Construct new stickerbook
@@ -36,6 +26,16 @@ class Stickerbook {
   constructor(config) {
     // assign default to the config, if it's missing
     const configWithDefaults = this._applyDefaultConfigs(config);
+
+    this.availableBrushes = {
+      circle: CircleBrush,
+      eraser: PencilEraserBrush,
+      marker: MarkerBrush,
+      pattern: PatternBrush,
+      pencil: PencilBrush,
+      spray: SprayBrush,
+      fill: FillBrush
+    };
 
     this._validateConfig(configWithDefaults);
 
@@ -260,7 +260,7 @@ class Stickerbook {
    * @returns {Object} Stickerbook
    */
   _updateCanvasState() {
-    const BrushClass = BRUSHES[this.state.brush];
+    const BrushClass = this.availableBrushes[this.state.brush];
     const newBrushType = (
       this._canvas.freeDrawingBrush.constructor.prototype !== BrushClass.prototype
     );
@@ -356,7 +356,7 @@ class Stickerbook {
       throw new Error(brushName + ' is not a permitted brush');
     }
 
-    if (Object.keys(BRUSHES).indexOf(brushName) === -1) {
+    if (Object.keys(this.availableBrushes).indexOf(brushName) === -1) {
       throw new Error(brushName + ' is an unknown brush type');
     }
 

--- a/src/validation-rules.js
+++ b/src/validation-rules.js
@@ -54,6 +54,9 @@ module.exports = {
           items: {
             type: 'string'
           }
+        },
+        custom: {
+          type: 'object'
         }
       }
     },

--- a/test/stickerbook.test.js
+++ b/test/stickerbook.test.js
@@ -58,6 +58,26 @@ describe('Stickerbook', () => {
     expect(stickerbook._config).toEqual(validConfig);
   });
 
+  it('allows custom brushes', () => {
+    const validConfig = createValidConfig();
+    validConfig.brush.custom = {
+      circle: fabric.CircleBrush
+    };
+    validConfig.brush.enabled.push('circle');
+    const stickerbook = new Stickerbook(validConfig);
+    stickerbook.setBrush('circle');
+  });
+
+  it('fails on custom brushes that aren\'t subclasses of base brush', () => {
+    const config = createValidConfig();
+    config.brush.custom = {
+      circle: function() { }
+    };
+    expect(
+      () => new Stickerbook(config)
+    ).toThrow('Custom brush "circle" is not an instance of fabric.BaseBrush');
+  });
+
   it('sets colors', () => {
     const stickerbook = createStickerbook();
     stickerbook.setColor('#0000FF');


### PR DESCRIPTION
An implementation for custom brush configuration in the drawing tool. Should resolve #14. Allows for any type of brush as long as they are subclasses of `fabric.BaseBrush`.