### PR TITLE
Simplifying logic around setting the next brush

### DIFF
--- a/src/stickerbook.js
+++ b/src/stickerbook.js
@@ -278,14 +278,7 @@ class Stickerbook {
    */
   _updateCanvasState() {
     const BrushClass = this.availableBrushes[this.state.brush];
-    const newBrushType = (
-      this._canvas.freeDrawingBrush.constructor.prototype !== BrushClass.prototype
-    );
-
-    if (newBrushType) {
-      const brush = new BrushClass(this._canvas, this.state.brushConfig);
-      this._canvas.freeDrawingBrush = brush;
-    }
+    this._canvas.freeDrawingBrush = new BrushClass(this._canvas, this.state.brushConfig);
 
     this._canvas.freeDrawingBrush.color = this.state.color;
     this._canvas.freeDrawingBrush.width = this.state.brushWidth;


### PR DESCRIPTION
It isn't terribly expensive to reinstantiate, and our existing logic
didn't check for brush configuration changes either. Instead of doing a
deep object comparison on the multiple objects, we'll simply blindly
reinstantiate.

The previous logic caused a bug where if you changed only the brush configuration but not the actual brush, it would continue using the old configuration. For example:

```
stickerbook.setBrush('bitmap-brush', { image: 'image1.png' });
stickerbook.setBrush('bitmap-brush', { image: 'image2.png' });
```

After this call, the drawing tool would still be using image1, rather than image2.