### PR TITLE
Feature/preserve aspect ratio in bitmap brushes

### DIFF
--- a/src/brushes/bitmap-brush.js
+++ b/src/brushes/bitmap-brush.js
@@ -1,6 +1,7 @@
 const BitmapBrush = fabric.util.createClass(fabric.BaseBrush, {
   initialize: function (canvas, options) {
     this.canvas = canvas;
+    this.aspectRatio = 1;
     this.loadImage(options.image);
   },
 
@@ -31,6 +32,7 @@ const BitmapBrush = fabric.util.createClass(fabric.BaseBrush, {
     context.putImageData(rawImageData, 0, 0);
 
     this.bitmap = tempCanvas;
+    this.aspectRatio = image.width / image.height;
   },
 
   getRgbColor: function (color) {
@@ -48,11 +50,12 @@ const BitmapBrush = fabric.util.createClass(fabric.BaseBrush, {
       return;
     }
 
-    var drawSize = this.width * 2;
-    var x = pointer.x - drawSize / 2;
-    var y = pointer.y - drawSize / 2;
+    var drawWidth = this.width * 2;
+    var drawHeight = this.width / this.aspectRatio * 2;
+    var x = pointer.x - drawWidth / 2;
+    var y = pointer.y - drawHeight / 2;
 
-    this.canvas.contextTop.drawImage(this.bitmap, x, y, drawSize, drawSize);
+    this.canvas.contextTop.drawImage(this.bitmap, x, y, drawWidth, drawHeight);
   },
 
   onMouseDown: function (pointer) {

--- a/test/stickerbook.test.js
+++ b/test/stickerbook.test.js
@@ -9,7 +9,8 @@ const historyFixture = require('./data/historyFixture.json');
 
 const images = {
   star: 'data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7',
-  dot: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg=='
+  dot: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==',
+  box: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAAECAYAAACk7+45AAAAFElEQVQYV2NkYGD4z8DAwMCImwEASjQEAY/F9H0AAAAASUVORK5CYII='
 };
 
 const createValidConfig = () => {
@@ -137,6 +138,23 @@ describe('Stickerbook', () => {
     var oldBrush = stickerbook._canvas.freeDrawingBrush;
     stickerbook.setBrush('bitmap', { image: images.star });
     expect(stickerbook._canvas.freeDrawingBrush).toNotBe(oldBrush);
+  });
+
+  it('correctly detects the aspect ratio of the image, rather assuming a square image', (done) => {
+    const stickerbook = createStickerbook();
+    stickerbook.setBrush('bitmap', { image: images.box });
+
+    // wait for the image to decode (shouldn't take long)
+    setTimeout(() => {
+      var actualAspectRatio = stickerbook._canvas.freeDrawingBrush.aspectRatio;
+
+      // should be close to 0.5
+      if(Math.abs(actualAspectRatio - 0.5) < 0.001) {
+        done();
+      } else {
+        done(new Error(`Expected aspect ratio of 0.5, got ${actualAspectRatio}`));
+      }
+    }, 10);
   });
 
   it('sets brush width', () => {


### PR DESCRIPTION
Fixes a small bug where bitmap brush items were forced to be a square image even if they had a different aspect ratio