### PR TITLE
Bugfix/resize mouse icon bug

### DIFF
--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -15,6 +15,16 @@ const mouseDownHandler = function (evt) {
   return this.placeSticker(this._canvas.getPointer(evt.e));
 };
 
+const mouseUpHandler = function(evt) {
+  let config = this._config.stickerControls || {};
+  let noBorder = config.cornerSize === 0 || !config.hasBorders;
+  if(this.state._stickerAdded && this.state.sticker.active && noBorder) {
+    this._canvas.setCursor('move');
+  }
+
+  return this;
+}
+
 const disableSelectabilityHandler = function (evt) {
   if (evt.target instanceof fabric.Image) {
     return;
@@ -99,6 +109,7 @@ const recordPropertyChange = function (historyManager, fabricEvent) {
 module.exports = {
   disableSelectabilityHandler: disableSelectabilityHandler,
   mouseDownHandler: mouseDownHandler,
+  mouseUpHandler: mouseUpHandler,
   recordObjectAddition: recordObjectAddition,
   recordPropertyChange: recordPropertyChange
 };

--- a/src/event-handlers.js
+++ b/src/event-handlers.js
@@ -15,7 +15,7 @@ const mouseDownHandler = function (evt) {
   return this.placeSticker(this._canvas.getPointer(evt.e));
 };
 
-const mouseUpHandler = function(evt) {
+const mouseUpHandler = function () {
   let config = this._config.stickerControls || {};
   let noBorder = config.cornerSize === 0 || !config.hasBorders;
   if(this.state._stickerAdded && this.state.sticker.active && noBorder) {
@@ -23,7 +23,7 @@ const mouseUpHandler = function(evt) {
   }
 
   return this;
-}
+};
 
 const disableSelectabilityHandler = function (evt) {
   if (evt.target instanceof fabric.Image) {

--- a/src/stickerbook.js
+++ b/src/stickerbook.js
@@ -19,6 +19,7 @@ const Promise = window.Promise || require('bluebird');
 const {
   disableSelectabilityHandler,
   mouseDownHandler,
+  mouseUpHandler,
   recordObjectAddition,
   recordPropertyChange
 } = require('./event-handlers');
@@ -140,6 +141,7 @@ class Stickerbook {
     // more opinionated handlers, these can be deactivated by implementors
     if (this._config.useDefaultEventHandlers) {
       canvas.on('mouse:down', mouseDownHandler.bind(this));
+      canvas.on('mouse:up', mouseUpHandler.bind(this));
     }
 
     // listen for objects to be added, so we can disable things from being selectable


### PR DESCRIPTION
Tiny bugfix: When placing a non-resizable image on the canvas, the resize cursor style still shows up. Here, I'm forcing the cursor to be correct.