### PR TITLE
Feature/remove bluebird

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,3 +345,8 @@ the page yourself (sorry, no live-reload at the time of writing).
 
 You can also run your own tests with `npm run test`. You can also see the test suite run by opening `test/index.html`
 in a browser after running `gulp build-test`.
+
+## Final notes
+As of 3.0.0, we're no longer binding a Promise polyfill to this library to help cut down on library size. If you need
+to run in [a browser that doesn't have native Promises](https://caniuse.com/#feat=promises), you'll need to polyfill
+it yourself.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "license": "MIT",
   "dependencies": {
     "ajv": "^4.7.7",
-    "bluebird": "^3.4.1",
     "fuzzy-select": "pbs/fuzzy-select.git#1.2.0"
   },
   "devDependencies": {

--- a/src/history-manager.js
+++ b/src/history-manager.js
@@ -1,5 +1,3 @@
-const Promise = window.Promise || require('bluebird');
-
 /**
  * Helper class for managing a state stack of changes made to the canvas. Stores deltas to save
  * space

--- a/src/stickerbook.js
+++ b/src/stickerbook.js
@@ -15,7 +15,6 @@ const BackgroundManager = require('./background-manager');
 const MarkerBrush = require('./brushes/marker-brush');
 const PatternBrush = require('./brushes/pattern-brush');
 const PencilEraserBrush = require('./brushes/pencil-eraser-brush');
-const Promise = window.Promise || require('bluebird');
 const {
   disableSelectabilityHandler,
   mouseDownHandler,

--- a/test/index.html
+++ b/test/index.html
@@ -4,6 +4,7 @@
         <title>OMG DOOD</title>
         <meta charset="utf-8">
         <link rel="stylesheet" type="text/css" href="../node_modules/mocha/mocha.css" />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.5.1/bluebird.min.js"></script>
     </head>
     <body>
         <div id="mocha"></div>


### PR DESCRIPTION
Removing bluebird Promise polyfill to cut down on library size, since most browsers are already supporting Promises.